### PR TITLE
Allow all items to be deselcted

### DIFF
--- a/src/github.com/icza/gowut/gwu/listbox.go
+++ b/src/github.com/icza/gowut/gwu/listbox.go
@@ -181,12 +181,12 @@ func (c *listBoxImpl) ClearSelected() {
 
 func (c *listBoxImpl) preprocessEvent(event Event, r *http.Request) {
 	value := r.FormValue(paramCompValue)
+	c.ClearSelected()
 	if len(value) == 0 {
 		return
 	}
 
 	// Set selected indices
-	c.ClearSelected()
 	for _, sidx := range strings.Split(value, ",") {
 		if idx, err := strconv.Atoi(sidx); err == nil {
 			c.selected[idx] = true


### PR DESCRIPTION
Fix early exit from the event handler function preventing deselection of all items in a listbox.
